### PR TITLE
Add helper function for step2.sh output formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,8 +225,9 @@ A few other Python arguments are not explicitly included in the default setup, b
 * `-v, --verbose`: enable verbose output (could be a bool or an int, if different verbosity levels are desired)
 By default, missing mode will try to get a list of output files from the `output` option, if it exists.
 
-One shell argument is effectively reserved if the user wants to use the [job management](#job-management) tools:
+Some shell arguments are effectively reserved if the user wants to use the [job management](#job-management) tools:
 * `-x [redir]`: xrootd redirector address or site name (for reading input files)
+* `-f`: switch to change the structure by which the output files are stored; from a "single folder, all files" solution to a solution with the pattern \<dir>/\<era>/\<sample>/\<filename>.root (default=False)
 
 ### Summary of options
 

--- a/scripts/jobExecCondor.sh
+++ b/scripts/jobExecCondor.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+# helper function to structure the ouput into folders
+structuredOutput() {
+	RES=""
+	TMP=${1/.//}
+	IFS='_' read -r -a array <<< "$TMP"
+	cut=$(expr ${#array[@]} - 2)
+	for index in "${!array[@]}"; do
+		if [[ $index -lt $cut ]]; then
+			if [[ $index -eq 0 ]]; then
+				RES=${RES}${array[index]}
+			else
+				RES=${RES}"_"${array[index]}
+			fi
+		elif [[ $index -eq $cut ]]; then
+			RES=${RES}"/"${array[index]}
+		else
+			RES=${RES}"_"${array[index]}
+		fi
+	done
+	echo ${RES}
+}
+
 # helper function to stage out via xrdcp
 stageOut() {
 	WAIT=5


### PR DESCRIPTION
Adds a new option to step2.sh to store the output files in a directory structure based on the era and dataset. Along with the README information this commit adds a helper function for formatting the filename.