### PR TITLE
More gfal-copy support

### DIFF
--- a/scripts/checkVomsTar.sh
+++ b/scripts/checkVomsTar.sh
@@ -34,7 +34,7 @@ if [[ "${XRDIR}" == *"root://"* ]]; then
 	CMD="xrdcp"
 elif [[ "${XRDIR}" == *"gsiftp://"* ]]; then
 	CMD="env -i X509_USER_PROXY=${X509_USER_PROXY} gfal-copy"
-elif [[ -n "${XRDIR}" ]
+elif [[ -n "${XRDIR}" ]]; then
 	echo "ERROR Unknown transfer protocol for the tarball"
 	exit 1
 fi

--- a/scripts/checkVomsTar.sh
+++ b/scripts/checkVomsTar.sh
@@ -34,7 +34,7 @@ if [[ "${XRDIR}" == *"root://"* ]]; then
 	CMD="xrdcp"
 elif [[ "${XRDIR}" == *"gsiftp://"* ]]; then
 	CMD="env -i X509_USER_PROXY=${X509_USER_PROXY} gfal-copy"
-else
+elif [[ -n "${XRDIR}" ]
 	echo "ERROR Unknown transfer protocol for the tarball"
 	exit 1
 fi

--- a/scripts/checkVomsTar.sh
+++ b/scripts/checkVomsTar.sh
@@ -3,6 +3,7 @@
 KEEPTAR=""
 XRDIR=""
 NOVOMS=""
+CMD=""
 # check arguments
 while getopts "nki:" opt; do
 	case "$opt" in
@@ -29,6 +30,14 @@ if [ -e ${CMSSW_VERSION}.tar.gz ]; then
 	ls -lth ${CMSSW_VERSION}.tar.gz
 fi
 
-if [ -n "$XRDIR" ]; then
-	xrdcp -f ${CMSSW_VERSION}.tar.gz ${XRDIR}/${CMSSW_VERSION}.tar.gz
+if [[ "${XRDIR}" == *"root://"* ]]; then
+	CMD="xrdcp"
+elif [[ "${XRDIR}" == *"gsiftp://"* ]]; then
+	CMD="env -i X509_USER_PROXY=${X509_USER_PROXY} gfal-copy"
+else
+	echo "ERROR Unknown transfer protocol for the tarball"
+fi
+
+if [ -n "$XRDIR" ] && [ -n "$CMD" ]; then
+	${CMD} -f ${CMSSW_VERSION}.tar.gz ${XRDIR}/${CMSSW_VERSION}.tar.gz
 fi

--- a/scripts/checkVomsTar.sh
+++ b/scripts/checkVomsTar.sh
@@ -36,6 +36,7 @@ elif [[ "${XRDIR}" == *"gsiftp://"* ]]; then
 	CMD="env -i X509_USER_PROXY=${X509_USER_PROXY} gfal-copy"
 else
 	echo "ERROR Unknown transfer protocol for the tarball"
+	exit 1
 fi
 
 if [ -n "$XRDIR" ] && [ -n "$CMD" ]; then


### PR DESCRIPTION
Add a gfal-copy capability to the checkVomsTar script. This does not change or add any user accessible options. This change has been tested and both the XRootD and gfal protocols work as expected.