### PR TITLE
Automated host OS detection

### DIFF
--- a/python/jobSubmitter.py
+++ b/python/jobSubmitter.py
@@ -282,6 +282,7 @@ class jobSubmitter(object):
 
     def generateExtra(self,job):
         job.patterns.update([
+            ("OSVERSION","rhel7" if "el7" in os.uname()[2] else "rhel6"),
             ("MYDISK",self.disk),
             ("MYMEMORY",self.memory),
             ("MYCPUS",self.cpus),

--- a/scripts/jobExecCondor.jdl
+++ b/scripts/jobExecCondor.jdl
@@ -1,6 +1,6 @@
 universe = vanilla
 Executable = jobExecCondor.sh
-+REQUIRED_OS = "rhel6"
++REQUIRED_OS = "OSVERSION"
 +DesiredOS = REQUIRED_OS
 request_disk = MYDISK
 request_memory = MYMEMORY


### PR DESCRIPTION
Automatically detect the host OS for the submission scripts. Since the typical workflow is to submit rhel6 jobs from a rhel6 host and rhel7 jobs from a rhel7 host this seems like a better solution that having to modify the JDL files whenever on a rhel7 host.