### PR TITLE
Site detection ClassAd

### DIFF
--- a/scripts/jobExecCondor.jdl
+++ b/scripts/jobExecCondor.jdl
@@ -20,3 +20,4 @@ on_exit_hold = ( (ExitBySignal == True) || (ExitCode != 0) )
 on_exit_hold_reason = strcat("Job held by ON_EXIT_HOLD due to ",\
 	ifThenElse((ExitBySignal == True), "exit by signal", \
 strcat("exit code ",ExitCode)), ".")
+job_machine_attrs = "GLIDEIN_CMSSite"


### PR DESCRIPTION
Add a ClassAd to the job named MachineAttrGLIDEIN_CMSSite0 which will contain the site where the job most recently ran. This is necessary to fix an ongoing problem with detecting when a job lands on T1_US_FNAL.