### PR TITLE
Checkpoint/recovery for job chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ __init__.py
 *.zip
 *.eps
 *.tar.gz
+
+# text files
+*.stdout
+*.stderr
+*.condor

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Default extra options:
 * `--sites [list]`: comma-separated list of sites for global pool running (if using CMS Connect) (default from `.prodconfig`)
 * `--env [args]`: args to run job in Singularity environment using cmssw-env (default = None)
 * `--intermediate`: specify that this is an intermediate job in a chain to disable staging out
+* `--singularity [image]`: specify singularity image for job (default = "")
 
 "Reserved", but not actually used by default:
 * `-o, --output [dir]`: path to output directory

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ At least one mode must be specified to run the script.
 
 Internally, `jobSubmitter` stores job information in a list `protoJobs`, where each entry is an instance of the class `protoJob`:
 * `name`: base name for the set of jobs (see [submit mode](#submit-mode))
+* `chainName`: alternate name if jobs are run in a chain (see [job chains](#job-chains) and [missing mode](#missing-mode))
 * `nums`: list of job numbers in this set (i.e. `$(Process)` values)
 * `njobs`: total number of jobs (used in [count mode](#count-mode))
 * `jdl`: JDL filename for this set of jobs
@@ -140,6 +141,8 @@ It also has an option `-u, --user [username]` to specify which user's jobs to ch
 The default value for `user` can be specified in the `.prodconfig` file (see [Configuration](#configuration)).
 The option `-q, --no-queue-arg` can also be used here; in this case, the JDL file will be modified
 with the list of jobs to be resubmitted (instead of using `-queue`).
+In case [job chains](#job-chains) are used, running jobs may have different names than the output files from finished jobs.
+The `protoJob.chainName` attribute is available to convert between the different naming schemes.
 
 This mode also relies on knowledge of HTCondor collectors and schedulers. Values for the LPC and CMS Connect
 are specified in the default `.prodconfig` file (see [Configuration](#configuration)).

--- a/README.md
+++ b/README.md
@@ -352,11 +352,13 @@ The python script's options are:
 * `-n NAME, --name NAME`: name for chain job (required)
 * `-j JDLS [JDLS ...], --jdls JDLS [JDLS ...]`: full paths to JDL files (at least one required)
 * `-l LOG, --log LOG`: log name prefix from first job (will be replaced w/ chain job name)
+* `-c, --checkpoint`: enable checkpointing (if a job fails, save output files from previous job in chain)
 
 The shell script's options are:
 * `-J [jobname]`: name for chain job
 * `-N [number]`: number of jobs in chain
 * `-P [process]`: process number (used to substitute for `$(Process)` if found in individual job arguments)
+* `-C`: enable checkpointing (see above)
 
 Several caveats currently apply:
 * The argument `-q, --no-queue-arg` should be used when preparing individual jobs.

--- a/python/.prodconfig
+++ b/python/.prodconfig
@@ -5,7 +5,7 @@ fnal = cmssrv268.fnal.gov,cmssrv605.fnal.gov
 cmscon = login.uscms.org
 [schedds]
 fnal = lpcschedd1.fnal.gov,lpcschedd2.fnal.gov,lpcschedd3.fnal.gov
-cmscon = login.uscms.org
+cmscon = login-el7.uscms.org
 [caches]
 $CMSSW_BASE/tmp = 1
 [manage]

--- a/python/createChain.py
+++ b/python/createChain.py
@@ -27,6 +27,7 @@ def createChain(jdls,name,log,checkpoint):
             concat_next = False
             for line in jfile:
                 line = line.rstrip()
+                if len(line)==0: continue
                 if concat_next: lines[-1] += line
                 else: lines.append(line)
                 # detect and handle multi-line

--- a/python/createChain.py
+++ b/python/createChain.py
@@ -51,6 +51,7 @@ def createChain(jdls,name,log,checkpoint):
             elif key==key_transfer:
                 for file in val.split(','):
                     file = file.strip()
+                    if len(file)==0: continue
                     # todo: find better way to handle "one input file per job" case
                     if "$(Process)" in file:
                         files = glob.glob(file.replace("$(Process)","*"))
@@ -89,15 +90,16 @@ def createChain(jdls,name,log,checkpoint):
     final["executable"] = "jobExecCondorChain.sh"
     # checkpoint info is kept using condor file transfer
     if checkpoint:
-        checkpoint_dir = "checkpoints/{}".format(name)
+        checkpoint_dir = "checkpoints_{}".format(name)
         checkpoint_fname1 = "checkpoint_{}_$(Process).txt".format(name)
         checkpoint_fname2 = "{}/{}".format(checkpoint_dir,checkpoint_fname1)
         final["should_transfer_files"] = "YES"
         final["transfer_output_files"] = checkpoint_fname1
-        final["transfer_output_remaps"] = "{} = {}".format(checkpoint_fname1,checkpoint_fname2)
+        final["transfer_output_remaps"] = '"{} = {}"'.format(checkpoint_fname1,checkpoint_fname2)
         # transfer whole dir to avoid having to make empty checkpoint files
-        final[key_transfer] = ','.join(final[key_transfer],checkpoint_dir)
+        final[key_transfer] = ','.join([final[key_transfer],checkpoint_dir])
         if not os.path.isdir(checkpoint_dir): os.makedirs(checkpoint_dir)
+        final["arguments"] += " -C"
     # write final jdl file
     finalname = "jobExecCondor_{}.jdl".format(name)
     with open(finalname,'w') as ffile:

--- a/python/jobSubmitter.py
+++ b/python/jobSubmitter.py
@@ -296,8 +296,8 @@ class jobSubmitter(object):
             ("SINGULARITYARGS",('+SingularityImage = "{}"'.format(self.singularity) if len(self.singularity)>0 else "")+("\nRequirements = HAS_SINGULARITY == True" if is_cms_connect else "")),
         ])
         # special option for CMS Connect
-        if is_cms_connect and len(self.sites)>0:
-            job.appends.append("+DESIRED_Sites = \""+self.sites+"\"")
+        if is_cms_connect:
+            if len(self.sites)>0: job.appends.append("+DESIRED_Sites = \""+self.sites+"\"")
             job.appends.append("+AvoidSystemPeriodicRemove = True")
         # special option for UMD
         if "umd.edu" in os.uname()[1]:

--- a/python/jobSubmitter.py
+++ b/python/jobSubmitter.py
@@ -56,11 +56,13 @@ class protoJob(object):
         self.nums = []
         self.jdl = ""
         self.name = "job"
+        self.chainName = ""
 
     def __repr__(self):
         line = (
             "protoJob:\n"
             "\tname = "+str(self.name)+"\n"
+            "\tchainName = "+str(self.chainName)+"\n"
             "\tnjobs = "+str(self.njobs)+"\n"
             "\tjdl = "+str(self.jdl)+"\n"
             "\tqueue = "+str(self.queue)+"\n"
@@ -344,8 +346,13 @@ class jobSubmitter(object):
 
     def doMissing(self,job):
         jobSet, jobDict = self.findJobs(job)
+        # replace name if necessary
+        if len(job.chainName)>0:
+            runSetTmp = {x.replace(job.chainName,job.name) for x in self.runSet}
+        else:
+            runSetTmp = self.runSet
         # find difference
-        diffSet = jobSet - self.filesSet - self.runSet
+        diffSet = jobSet - self.filesSet - runSetTmp
         diffList = list(sorted(diffSet))
         if len(diffList)>0:
             if len(self.resub)>0:
@@ -464,7 +471,7 @@ class jobSubmitter(object):
         self.filesSet = self.filesSet - jobSet
 
         for jobname in finishedJobSet:
-            # gets .condor. .stdout, .stderr
+            # gets .condor, .stdout, .stderr
             for fname in glob.glob(jobname+"_*.*"):
                 shutil.move(fname,self.logdir)
 

--- a/scripts/jobExecCondor.jdl
+++ b/scripts/jobExecCondor.jdl
@@ -21,3 +21,4 @@ on_exit_hold_reason = strcat("Job held by ON_EXIT_HOLD due to ",\
 	ifThenElse((ExitBySignal == True), "exit by signal", \
 strcat("exit code ",ExitCode)), ".")
 job_machine_attrs = "GLIDEIN_CMSSite"
+SINGULARITYARGS

--- a/scripts/jobExecCondor.sh
+++ b/scripts/jobExecCondor.sh
@@ -5,9 +5,13 @@ stageOut() {
 	if [ $INTERCHAIN -eq 1 ]; then
 		# store current path, command, args to rerun later if needed
 		if [ -n "$CHECKPOINT_CURR" ]; then
+			# execute in subshell to avoid having to cd back
+			echo "(" >> ${CHECKPOINT_CURR}
 			PATH_TMP=$(realpath --relative-to=${JOBDIR_BASE}/${JOB_CURR} $PWD)
 			echo "mkdir -p $PATH_TMP && cd $PATH_TMP" >> ${CHECKPOINT_CURR}
-			echo "stageOut $@" >> ${CHECKPOINT_CURR}
+			# preserve quoting in args
+			echo "stageOut "$(printf '%q ' "$@") >> ${CHECKPOINT_CURR}
+			echo ")" >> ${CHECKPOINT_CURR}
 		fi
 
 		return 0
@@ -69,7 +73,7 @@ stageOut() {
 			;;
 			c) CLEANUP="$OPTARG"
 			;;
-			r) REVERSE=1
+			R) REVERSE=1
 			;;
 		esac
 	done

--- a/scripts/jobExecCondor.sh
+++ b/scripts/jobExecCondor.sh
@@ -133,6 +133,12 @@ getFromClassAd() {
 	fi
 }
 
+# needed when using Singularity container for SLC6 (also works for SLC7)
+export X509_CERT_DIR=/cvmfs/grid.cern.ch/etc/grid-security/certificates
+export X509_VOMSES=/cvmfs/grid.cern.ch/etc/grid-security/vomses
+export VOMS_USERCONF=/cvmfs/grid.cern.ch/etc/grid-security/vomses
+export X509_VOMSDIR=/cvmfs/grid.cern.ch/etc/grid-security/vomsdir
+
 # check default arguments
 TOPDIR=$PWD
 export SCRIPTS=""

--- a/scripts/jobExecCondor.sh
+++ b/scripts/jobExecCondor.sh
@@ -86,7 +86,7 @@ stageOut() {
 	if [ "$REVERSE" -eq 1 ]; then
 		TMPPUT="$INPUT"
 		INPUT="$OUTPUT"
-		OUTPUT="$INPUT"
+		OUTPUT="$TMPPUT"
 		# ensure expected output directory exists
 		mkdir -p $(dirname $OUTPUT)
 	fi

--- a/scripts/jobExecCondorChain.sh
+++ b/scripts/jobExecCondorChain.sh
@@ -43,6 +43,9 @@ if [ -f "$CHECKPOINT_TXT" ]; then
 		# set up stagein commands (reverse of stageout)
 		sed -i 's/stageOut/stageOut -R/g' ${CHECKPOINT_IN}
 	fi
+# make sure output file exists (before running any jobs: avoid condor error message about missing output file)
+else
+	touch ${CHECKPOINT_OUT}
 fi
 
 # execute each job in series
@@ -104,8 +107,3 @@ for ((i=${FIRST_STEP}; i<${NJOBS}; i++)); do
 	fi
 	cd ..
 done
-
-# make sure output file exists
-if [ ! -f "$CHECKPOINT_OUT" ]; then
-	touch ${CHECKPOINT_OUT}
-fi

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -4,4 +4,4 @@ checkVomsTar.sh
 step1.sh
 jobExecCondor.sh
 jobExecCondor.jdl
-
+jobExecCondorChain.sh

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -5,3 +5,4 @@ step1.sh
 jobExecCondor.sh
 jobExecCondor.jdl
 jobExecCondorChain.sh
+manageJobs.py

--- a/test/CACHEDIR.TAG
+++ b/test/CACHEDIR.TAG
@@ -1,0 +1,1 @@
+Signature: 8a477f597d28d172789f06886806bc55\n# This file is a cache directory tag.\n# For information about cache directory tags, see:\n#       http://www.brynosaurus.com/cachedir/

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,49 @@
+# CondorProduction Tests
+
+This directory provides a simple example of a fully-implemented `jobSubmitter` with two different operations.
+
+The available options for the job submitter are:
+* `-N, --nParts [num]`: number of parts to process (default = 1)
+* `--name [name]`: job name (default = test)
+* `--io`: use I/O options (default = False)
+* `--indir [dir]`: input file directory (local or PFN) (default = )
+* `--outdir [dir]`: output file directory (local or PFN) (default = )
+* `--inpre [str]`: input file prefix (default = )
+* `--outpre [str]`: output file prefix (required) (default = )
+* `--fail [num]`: fail with specified error code (default = 0)
+
+The default operation (if `--io` is not provided) will just print some information on the worker node.
+
+The secondary, more involved operation is a mockup of a job that takes inputs and produces outputs.
+This operation is useful to test the `stageOut` function and to construct and test job chains.
+For this operation, the `--outdir` and `--outpre` arguments are required, but the input arguments are not necessarily required.
+
+## Setup
+
+```bash
+python $CMSSW_BASE/src/Condor/Production/python/linkScripts.py
+ln -s $CMSSW_BASE/src/Condor/Production/python/manageJobs.py .
+```
+
+## Example commands
+
+These example commands test the checkpoint/recovery feature of job chains.
+
+Before running these commands, set the shell variable `OUTDIR` to the directory of your choice.
+
+```bash
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job0 --io --outdir $OUTDIR --outpre step1
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job1 --io --indir ../job0 --inpre step1 --outdir $OUTDIR --outpre step2 --fail 1
+python submitJobs.py -p -k -t cmsrel --no-queue-arg -N 1 --name job2 --io --indir ../job1 --inpre step2 --outdir $OUTDIR --outpre step3
+python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl
+condor_submit jobExecCondor_chainTest.jdl
+```
+
+The job will fail and be held because an artificial failure was requested in job1.
+
+To remove this artificial failure, recover the output from job0, and finish the rest of the job chain, rerun the relevant commands and release the job:
+```bash
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job1 --io --indir ../job0 --inpre step1 --outdir $OUTDIR --outpre step2
+python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl
+python manageJobs.py -hsa
+```

--- a/test/README.md
+++ b/test/README.md
@@ -28,22 +28,39 @@ ln -s $CMSSW_BASE/src/Condor/Production/python/manageJobs.py .
 ## Example commands
 
 These example commands test the checkpoint/recovery feature of job chains.
+Specifically, this series of commands simulates the failure of a job such that a checkpoint is created from the previous job,
+and then the failure of another job along with the failure to create a checkpoint, in which case the previous checkpoint is reused.
 
 Before running these commands, set the shell variable `OUTDIR` to the directory of your choice.
 
 ```bash
 python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job0 --io --outdir $OUTDIR --outpre step1
 python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job1 --io --indir ../job0 --inpre step1 --outdir $OUTDIR --outpre step2 --fail 1
-python submitJobs.py -p -k -t cmsrel --no-queue-arg -N 1 --name job2 --io --indir ../job1 --inpre step2 --outdir $OUTDIR --outpre step3
-python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job2 --io --indir ../job1 --inpre step2 --outdir $OUTDIR --outpre step3
+python submitJobs.py -p -k -t cmsrel --no-queue-arg -N 1 --name job3 --io --indir ../job2 --inpre step3 --outdir $OUTDIR --outpre step4
+python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job3.jdl
 condor_submit jobExecCondor_chainTest.jdl
 ```
 
 The job will fail and be held because an artificial failure was requested in job1.
 
-To remove this artificial failure, recover the output from job0, and finish the rest of the job chain, rerun the relevant commands and release the job:
+Next, remove this artificial failure, recover the output from job0, and keep running until the next failure.
+Before running the next set of commands, set `OUTDIR` to a *non-existent* directory (in order to simulate the failure to create a checkpoint).
 ```bash
 python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job1 --io --indir ../job0 --inpre step1 --outdir $OUTDIR --outpre step2
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job2 --io --indir ../job1 --inpre step2 --outdir $OUTDIR --outpre step3 --fail 1
+python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job3.jdl
+python manageJobs.py -hsa
+```
+
+The job will fail and be held because of the artificial failure in job2.
+Additionally, the failure to create a checkpoint will be reported, so the previous checkpoint for job0 will be used again.
+
+Finally, remove all failures and finish the rest of the job chain.
+Before running the next set of commands, set `OUTDIR` back to the directory you originally chose.
+```bash
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job1 --io --indir ../job0 --inpre step1 --outdir $OUTDIR --outpre step2
+python submitJobs.py -p -k -t cmsrel --no-queue-arg --intermediate -N 1 --name job2 --io --indir ../job1 --inpre step2 --outdir $OUTDIR --outpre step3
 python $CMSSW_BASE/src/Condor/Production/python/createChain.py -n chainTest -l job0 -c -j $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job0.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job1.jdl $CMSSW_BASE/src/Condor/Production/test/jobExecCondor_job2.jdl
 python manageJobs.py -hsa
 ```

--- a/test/jobSubmitterTest.py
+++ b/test/jobSubmitterTest.py
@@ -8,10 +8,27 @@ class jobSubmitterTest(jobSubmitter):
     def addExtraOptions(self,parser):
         super(jobSubmitterTest,self).addExtraOptions(parser)
         parser.add_option("-N", "--nParts", dest="nParts", default=1, type="int", help="number of parts to process (default = %default)")
+        parser.add_option("--name", dest="name", default="test", help="job name (default = %default)")
+        parser.add_option("--io", dest="io", default=False, action="store_true", help="use I/O options (default = %default)")
+        parser.add_option("--indir", dest="indir", default="", help="input file directory (local or PFN) (default = %default)")
+        parser.add_option("--outdir", dest="outdir", default="", help="output file directory (local or PFN) (default = %default)")
+        parser.add_option("--inpre", dest="inpre", default="", help="input file prefix (default = %default)")
+        parser.add_option("--outpre", dest="outpre", default="", help="output file prefix (required) (default = %default)")
+        parser.add_option("--fail", dest="fail", default=0, help="fail with specified error code (default = %default)")
+
+    def checkExtraOptions(self,options,parser):
+        super(jobSubmitterTest,self).checkExtraOptions(options,parser)
+
+        if options.io:
+            # input is not necessarily required
+            if len(options.outdir)==0:
+                parser.error("Required option: --outdir [directory]")
+            if len(options.outpre)==0:
+                parser.error("Required option: --outpre [prefix]")
 
     def generateSubmission(self):
         job = protoJob()
-        job.name = "test"
+        job.name = self.name
         self.generatePerJob(job)
 
         for iJob in xrange(self.nParts):
@@ -26,5 +43,5 @@ class jobSubmitterTest(jobSubmitter):
         job.patterns.update([
             ("JOBNAME",job.name+"_part$(Process)_$(Cluster)"),
             ("EXTRAINPUTS",""),
-            ("EXTRAARGS",""),
+            ("EXTRAARGS","-j "+job.name+(" -i "+self.indir if len(self.indir)>0 else "")+" -o "+self.outdir+(" -n "+self.inpre if len(self.inpre)>0 else "")+" -u "+self.outpre+" -f "+str(self.fail)+" -p $(Process)" if self.io else ""),
         ])

--- a/test/test.sh
+++ b/test/test.sh
@@ -72,6 +72,10 @@ else
 			xrdcp ${INDIR}/${INFNAME} tmp/
 			INDIR=tmp
 		fi
+		if [ ! -f ${INDIR}/${INFNAME} ]; then
+			echo "Missing input: ${INFNAME}"
+			exit 1
+		fi
 		cat ${INDIR}/${INFNAME} >> ${OUTFNAME}
 	fi
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,13 +1,101 @@
 #!/bin/bash
 
-echo "This is a test job. It will print the current directory, contents, and environment."
+echo "Starting job on "`date` # to display the start date
+echo "Running on "`uname -a` # to display the machine where the job is running
+echo "System release "`cat /etc/redhat-release` # and the system release
 echo ""
-echo "Current directory:"
-echo $PWD
-echo ""
-echo "Current directory listing:"
-ls -ltha
-echo ""
-echo "Current environment:"
-printenv
 
+export JOBNAME=""
+export PART=""
+export INDIR=""
+export OUTDIR=""
+export INDPRE=""
+export OUTPRE=""
+export FAIL=0
+export OPTIND=1
+while [[ $OPTIND -le $# ]]; do
+	OPTOLD=$OPTIND
+	# getopts in silent mode, don't exit on errors
+	getopts ":j:p:i:o:n:u:f:" opt || status=$?
+	case "$opt" in
+		j) export JOBNAME=$OPTARG
+		;;
+		p) export PART=$OPTARG
+		;;
+		i) export INDIR=$OPTARG
+		;;
+		o) export OUTDIR=$OPTARG
+		;;
+		n) export INPRE=$OPTARG
+		;;
+		u) export OUTPRE=$OPTARG
+		;;
+		f) export FAIL=$OPTARG
+		;;
+		# keep going if getopts had an error, but make sure not to skip anything
+		\? | :) OPTIND=$((OPTOLD+1))
+		;;
+	esac
+done
+
+# default mode
+if [ -z "$PART" ]; then
+	echo "This is a test job. It will print the current directory, contents, and environment."
+	echo ""
+	echo "Current directory:"
+	echo $PWD
+	echo ""
+	echo "Current directory listing:"
+	ls -ltha
+	echo ""
+	echo "Current environment:"
+	printenv
+# IO mode
+else
+	echo "parameter set:"
+	echo "JOBNAME: $JOBNAME"
+	echo "PART: $PART"
+	echo "INDIR: $INDIR"
+	echo "OUTDIR: $OUTDIR"
+	echo "INPRE: $INPRE"
+	echo "OUTPRE: $OUTPRE"
+
+	OUTFNAME=${OUTPRE}_${PART}.log
+	# get input if any
+	if [ -n "$INDIR" ]; then
+		INFNAME=${INPRE}_${PART}.log
+		if [[ "$INDIR" == "root://"* ]]; then
+			mkdir -p tmp
+			xrdcp ${INDIR}/${INFNAME} tmp/
+			INDIR=tmp
+		fi
+		cat ${INDIR}/${INFNAME} >> ${OUTFNAME}
+	fi
+
+	if [[ $FAIL -ne 0 ]]; then
+		echo "artificial failure $FAIL"
+		exit $FAIL
+	fi
+
+	# create output
+	echo "$JOBNAME $PART" >> ${OUTFNAME}
+
+	# check for gfal case
+	CMDSTR="xrdcp"
+	GFLAG=""
+	if [[ "$OUTDIR" == "gsiftp://"* ]]; then
+		CMDSTR="gfal-copy"
+		GFLAG="-g"
+	fi
+	# stageout
+	echo "$CMDSTR output for condor"
+	for FILE in *.log; do
+		echo "${CMDSTR} -f ${FILE} ${OUTDIR}/${FILE}"
+		stageOut ${GFLAG} -x "-f" -i ${FILE} -o ${OUTDIR}/${FILE} -r -c '*.log' 2>&1
+		XRDEXIT=$?
+		if [[ $XRDEXIT -ne 0 ]]; then
+			echo "exit code $XRDEXIT, failure in ${CMDSTR}"
+			exit $XRDEXIT
+		fi
+	done
+fi

--- a/test/test.sh
+++ b/test/test.sh
@@ -3,6 +3,9 @@
 echo "Starting job on "`date` # to display the start date
 echo "Running on "`uname -a` # to display the machine where the job is running
 echo "System release "`cat /etc/redhat-release` # and the system release
+if [ -n "$SINGULARITY_CONTAINER" ]; then
+	echo "Singularity container $SINGULARITY_CONTAINER"
+fi
 echo ""
 
 export JOBNAME=""


### PR DESCRIPTION
This PR primarily serves to add a feature for job chains: if an intermediate job in the chain fails, the output from the previous step can be staged out as a checkpoint, and then recovered when the job is released. This avoids having to rerun previous steps, as long as enough space is available on the storage element to host the intermediate output temporarily. Hence, this option is not enabled by default, but has to be activated with the flag `-c`.

The test job setup is enhanced to be able to run job chains in a meaningful way, and this testing procedure is now document.

Other updates:
* added an option to run the entire job in a singularity container
* minor fixes for CMS Connect