### PR TITLE
Job resubmission based on input file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,14 +358,9 @@ by the `-x` option.
 
 When using the `-X` option, a user may indicate a preference for specific sites in two ways:
 1. The user can broadly prefer sites located in the United States using the `-U` option
-2. The user can add a list of sites to the `.prodconfig` file of the form:
-```ini
-[manage]
-preferredsites = [sites]
-```
-where `[sites]` is a comma separated list of site names in descending order of preference.
+2. The user can specify a list of preferred sites using the `.prodconfig` file (see [Configuration](#configuration))
 
-Limitation: the `-X` option relies upon `dasgoclient` for finding the site information for a given file. It is therefore limited by the accuracy of `DAS` and only works for centrally produced/tracked input files.
+Limitation: the `-X` option relies upon [dasgoclient](https://github.com/dmwm/dasgoclient) for finding the site information for a given file. It is therefore limited by the accuracy of [DAS](https://cmsweb.cern.ch/das/) and only works for centrally produced/tracked [CMS](https://cms.cern/) input files.
 
 ## Job chains
 
@@ -416,12 +411,13 @@ Expected categories and values:
 * `manage`:
     * `dir = [dir]`: backup directory for logs from failing jobs
     * `defaultredir = [dir]`: default xrootd redirector (if using site name)
+    * `preferredsites = [site(s)]`: list of preferred sites for input file specific job resubmission (comma-separated list, descending order of preference)
 * `collectors`:
     * `[name] = [server(s)]`: name and associated collector server(s) (comma-separated list)
 * `schedds`:
     * `[name] = [server(s)]`: name and associated schedd server(s) (comma-separated list)
 * `caches`:
-	* `[dir] = [val]`: directory and cache status (1 = cache, 0 = uncache) (one entry per directory)
+    * `[dir] = [val]`: directory and cache status (1 = cache, 0 = uncache) (one entry per directory)
 
 The name used for the collector and associated schedd(s) must match.
 

--- a/README.md
+++ b/README.md
@@ -328,6 +328,13 @@ It uses a number of command line options to specify how to display job informati
 * `-w, --why`: show why a job was held
 * `-m, --matched`: show site and machine to which the job matched (for CMS Connect)
 * `-p, --progress`: show job progress (time and nevents)
+* `-X, --root-resubmit`: resubmit the jobs based on where the input files are located
+* `-C INPUTFILECLASSAS, --input-file-classad=INPUTFILECLASSAS`: HTCondor ClassAd which contains the input file(s) being used within the job (used in combination with `-X`)
+* `-D, --dry-run`: don't actually resubmit any jobs (used in combination with `-X`)
+* `-K LOGKEY, --log_key=LOGKEY`: key to use to find the correct line(s) in the log file (used in combination with `-X`)
+* `-L LOGPATH, --log_path=LOGPATH`: path to the job logs (used in combination with `-X`, default = `pwd`)
+* `-U, --prefer-us-sites`: preferentially select US sites over others (used in combination with `-X`)
+* `-V, --verbose`: be more verbose when printing out the resubmission information for each job (used in combination with `-X`)
 * `--add-sites=ADDSITES`: comma-separated list of global pool sites to add
 * `--rm-sites=RMSITES`: comma-separated list of global pool sites to remove
 * `--stuck-threshold [num]`: threshold in hours to define stuck jobs (default = 12)
@@ -337,6 +344,25 @@ It uses a number of command line options to specify how to display job informati
 The options `-h`, `-i`, `-r`, `-f` are exclusive. The options `-s` and `-k` are also exclusive. The option `-a` is currently only supported
 at the LPC (where each interactive node has its own scheduler). The script can ssh to each node and run itself to modify the jobs
 on that node (because each scheduler can only be accessed for write operations from its respective node).
+
+The option `-X` will resubmit the jobs (just like `-s`), except that it will tell the job to get its input file from a specific site based on the list of sites where that file
+is located and some user preferences. Therefore, the options `-X` and `-s` are exclusive, as are the options `-X` and `-k`. The options `-C`, `-D`, `-K`, `-L`, `-U`, and `-V`
+are only applicable when using the option `-X`. There are two ways in which the program can find the appropriate input file(s) for the job:
+1. specify an HTCondor ClassAd name, where the ClassAd contains a comma separated list of files (`-C`).
+2. specify the location of a set of log files and a key with which to parse the logs files (`-L`/`-K`). It is expected that the log will contain a single line with a comma separated list of files.
+This is similar in spirit to using the `-x` option, except in that case all of the resubmitted jobs will try to access the input files from a user specified location. In this case,
+the user doesn't specify a particular location, but a set of loose preferences (more on that in a moment). If both the `-X` and `-x` options are specified, then the jobs will preferentially
+read their input from the site found using the automated mechanism. However, if no suitable site can be found, then the job will be resubmitted using the xrootd redirector (or site name) specified
+by the `-x` option.
+
+When using the `-X` option, a user may indicate a preference for specific sites in two ways:
+1. The user can broadly prefer sites located in the United States using the `-U` option
+2. The user can add a list of sites to the `.prodconfig` file of the form:
+```ini
+[manage]
+preferredsites = [sites]
+```
+where `[sites]` is a comma separated list of site names in descending order of preference.
 
 ## Job chains
 

--- a/README.md
+++ b/README.md
@@ -328,8 +328,8 @@ It uses a number of command line options to specify how to display job informati
 * `-w, --why`: show why a job was held
 * `-m, --matched`: show site and machine to which the job matched (for CMS Connect)
 * `-p, --progress`: show job progress (time and nevents)
-* `-X, --root-resubmit`: resubmit the jobs based on where the input files are located
-* `-C INPUTFILECLASSAS, --input-file-classad=INPUTFILECLASSAS`: HTCondor ClassAd which contains the input file(s) being used within the job (used in combination with `-X`)
+* `-X, --xrootd-resubmit`: resubmit the jobs based on where the input files are located
+* `-C INPUTFILECLASSAD, --input-file-classad=INPUTFILECLASSAD`: HTCondor ClassAd which contains the input file(s) being used within the job (used in combination with `-X`)
 * `-D, --dry-run`: don't actually resubmit any jobs (used in combination with `-X`)
 * `-K LOGKEY, --log_key=LOGKEY`: key to use to find the correct line(s) in the log file (used in combination with `-X`)
 * `-L LOGPATH, --log_path=LOGPATH`: path to the job logs (used in combination with `-X`, default = `pwd`)
@@ -350,6 +350,7 @@ is located and some user preferences. Therefore, the options `-X` and `-s` are e
 are only applicable when using the option `-X`. There are two ways in which the program can find the appropriate input file(s) for the job:
 1. specify an HTCondor ClassAd name, where the ClassAd contains a comma separated list of files (`-C`).
 2. specify the location of a set of log files and a key with which to parse the logs files (`-L`/`-K`). It is expected that the log will contain a single line with a comma separated list of files.
+
 This is similar in spirit to using the `-x` option, except in that case all of the resubmitted jobs will try to access the input files from a user specified location. In this case,
 the user doesn't specify a particular location, but a set of loose preferences (more on that in a moment). If both the `-X` and `-x` options are specified, then the jobs will preferentially
 read their input from the site found using the automated mechanism. However, if no suitable site can be found, then the job will be resubmitted using the xrootd redirector (or site name) specified
@@ -363,6 +364,8 @@ When using the `-X` option, a user may indicate a preference for specific sites 
 preferredsites = [sites]
 ```
 where `[sites]` is a comma separated list of site names in descending order of preference.
+
+Limitation: the `-X` option relies upon `dasgoclient` for finding the site information for a given file. It is therefore limited by the accuracy of `DAS` and only works for centrally produced/tracked input files.
 
 ## Job chains
 

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ It uses a number of command line options to specify how to display job informati
 * `-D, --dry-run`: don't actually resubmit any jobs (used in combination with `-X`)
 * `-K LOGKEY, --log_key=LOGKEY`: key to use to find the correct line(s) in the log file (used in combination with `-X`)
 * `-L LOGPATH, --log_path=LOGPATH`: path to the job logs (used in combination with `-X`, default = `pwd`)
-* `-U, --prefer-us-sites`: preferentially select US sites over others (used in combination with `-X`)
+* `-U, --prefer-us-sites`: prefer reading inputs from US sites over others (used in combination with `-X`)
 * `-V, --verbose`: be more verbose when printing out the resubmission information for each job (used in combination with `-X`)
 * `--add-sites=ADDSITES`: comma-separated list of global pool sites to add
 * `--rm-sites=RMSITES`: comma-separated list of global pool sites to remove
@@ -348,17 +348,14 @@ on that node (because each scheduler can only be accessed for write operations f
 The option `-X` will resubmit the jobs (just like `-s`), except that it will tell the job to get its input file from a specific site based on the list of sites where that file
 is located and some user preferences. Therefore, the options `-X` and `-s` are exclusive, as are the options `-X` and `-k`. The options `-C`, `-D`, `-K`, `-L`, `-U`, and `-V`
 are only applicable when using the option `-X`. There are two ways in which the program can find the appropriate input file(s) for the job:
-1. specify an HTCondor ClassAd name, where the ClassAd contains a comma separated list of files (`-C`).
-2. specify the location of a set of log files and a key with which to parse the logs files (`-L`/`-K`). It is expected that the log will contain a single line with a comma separated list of files.
+1. specify an HTCondor ClassAd name, where the ClassAd contains a comma-separated list of files (`-C`).
+2. specify the location of a set of log files and a key with which to parse the log files (`-L`/`-K`). It is expected that the log will contain a single line with a comma-separated list of files.
 
-This is similar in spirit to using the `-x` option, except in that case all of the resubmitted jobs will try to access the input files from a user specified location. In this case,
-the user doesn't specify a particular location, but a set of loose preferences (more on that in a moment). If both the `-X` and `-x` options are specified, then the jobs will preferentially
-read their input from the site found using the automated mechanism. However, if no suitable site can be found, then the job will be resubmitted using the xrootd redirector (or site name) specified
-by the `-x` option.
+The `-x` and `-X` options are similar. If just the `-x` option is used, all of the resubmitted jobs will try to access the input files from a user-specified location. If just the `-X` option is used, the user doesn't specify a particular location, but a set of loose preferences (see below). If both the `-X` and `-x` options are used, then the jobs will preferentially read their input from the site found automatically, with the redirector or site name given by `-x` as a fallback if no suitable site is found.
 
 When using the `-X` option, a user may indicate a preference for specific sites in two ways:
 1. The user can broadly prefer sites located in the United States using the `-U` option
-2. The user can specify a list of preferred sites using the `.prodconfig` file (see [Configuration](#configuration))
+2. The user can specify a list of preferred sites using the attribute `preferredsites` in the `.prodconfig` file (see [Configuration](#configuration))
 
 Limitation: the `-X` option relies upon [dasgoclient](https://github.com/dmwm/dasgoclient) for finding the site information for a given file. It is therefore limited by the accuracy of [DAS](https://cmsweb.cern.ch/das/) and only works for centrally produced/tracked [CMS](https://cms.cern/) input files.
 

--- a/python/file_finder.py
+++ b/python/file_finder.py
@@ -79,7 +79,7 @@ def lines_that_contain(string, fp):
 def select_site(sites, preferred_sites = None, prefer_us_sites = False):
     selected = None
     sites = [s.replace("_Disk","") for s in sites if s is not None and "Tape" not in s]
-    sites = sorted(sites, key = lambda x: ("US" in x.split('_')[1] and prefer_us_sites), reverse = True)
+    sites = sorted(sites, key = lambda x: (prefer_us_sites and "US" in x.split('_')[1]), reverse = True)
     if preferred_sites is not None:
         for psite in reversed(preferred_sites):
             if psite in sites:

--- a/python/file_finder.py
+++ b/python/file_finder.py
@@ -105,7 +105,7 @@ def find_input_file_site_per_job(classad = "", condor_jobs = None, log_key = "",
         file_per_job = get_input_file(log_path, condor_jobs, log_key, verbose)
     else:
         fprint("file_finder.py: error: You must select a method to obtain the input file information (--classad and/or --log_path/--log_key).")
-        sys.exit(3)
+        sys.exit(2)
     
     file_and_site_per_file = find_site(file_per_job, preferred_sites, prefer_us_sites, verbose)
 

--- a/python/file_finder.py
+++ b/python/file_finder.py
@@ -1,0 +1,112 @@
+import argparse
+import os
+import subprocess
+import sys
+
+#From: https://stackoverflow.com/questions/1883980/find-the-nth-occurrence-of-substring-in-a-string
+def find_nth(haystack, needle, n):
+    start = haystack.find(needle)
+    while start >= 0 and n > 1:
+        start = haystack.find(needle, start+len(needle))
+        n -= 1
+    return start
+
+def find_site(file_per_job, prefer_us_sites = False):
+    file_and_site_per_job = {}
+    print "Finding the sites for each file ...",
+    sys.stdout.flush()
+    for i, (job, file) in enumerate(file_per_job.iteritems()):
+        if file is None:
+            file_and_site_per_job[job] = (file,None,[None])
+        else:
+            cmd = "dasgoclient -query=\"site file=" + file + "\""
+            p = subprocess.Popen(cmd, shell = True, stdout=subprocess.PIPE)
+            out, err = p.communicate()
+            sites = [None] if "WARNING:" in out else out.split()
+            site = select_site(sites, prefer_us_sites)
+            file_and_site_per_job[job] = (file,site,sites)
+    print "DONE"
+    return file_and_site_per_job
+
+def get_input_file(basepath, jobs, key):
+    file_per_job = {}
+    print "Finding the input file for each job ...",
+    sys.stdout.flush()
+    for job in jobs:
+        output_file = basepath+job.stdout+".stdout"
+        if not os.path.exists(output_file):
+            file_per_job[job] = None
+        else:
+            with open(output_file, 'r') as f:
+                for line in lines_that_contain(key, f):
+                    line = line[line.find("/store/"):line.rfind(".root")+5]
+                    line = line.split(",")[0]
+                    if "/store/test/xrootd/" in line:
+                        line = line[find_nth(line,"/store/",2):]
+                    file_per_job[job] = line
+    print "DONE"
+    return file_per_job
+
+def get_input_file_from_classad(jobs, classad):
+    file_per_job = {}
+    print "Finding the input file for each job ...",
+    sys.stdout.flush()
+    for job in jobs:
+        if hasattr(job, "inputFiles"):
+            input_file = job.inputFiles.split(",")[0]
+            input_file = input_file[input_file.find("/store/"):input_file.rfind(".root")+5]
+            if "/store/test/xrootd/" in input_file:
+                input_file = input_file[find_nth(input_file,"/store/",2):]
+            file_per_job[job] = input_file
+        else:
+            file_per_job[job] = None
+    print "DONE"
+    return file_per_job        
+
+def lines_that_contain(string, fp):
+    return [line for line in fp if string in line]
+
+def select_site(sites, prefer_us_sites = False):
+    selected = None
+    sites = [s for s in sites if s is not None and "Tape" not in s]
+    sites = sorted(sites, key = lambda x: ("FNAL" in x.split('_')[2], "US" in x.split('_')[1] and prefer_us_sites), reverse = True)
+    if len(sites) > 0:
+        selected = sites[0]
+    if selected is not None:
+        selected = selected.replace("_Disk","")
+    return selected
+
+def find_input_file_site_per_job(argv = None, condor_jobs = None):
+    if argv is None:
+        argv = sys.argv[1:]
+    
+    if condor_jobs is None:
+        return
+
+    parser = argparse.ArgumentParser(prog='file_finder_resubmitter.py', description = "Resubmit jobs using input from a specific site.")
+    parser.add_argument("-c", "--classad", default = "", help = "The HTCondor ClassAd which contains the input file(s) being used within the job (default = %(default)s)")
+    parser.add_argument("-k", "--log_key", default = "", help="Key to use to find the correct line(s) in the log file (default = %(default)s)")
+    parser.add_argument("-l", "--log_path", default = "", help = "Path of the job logs (default: %(default)s)")
+    parser.add_argument("-u", "--prefer_us_sites", action = "store_true", default = False, help = "Preferentially select US sites over others (default: %(default)s)")
+    parser.add_argument("--version", action='version', version='%(prog)s v1.0.0')
+    args = parser.parse_args(args=argv)
+
+    if args.log_path and args.log_path[-1] != '/':
+        args.log_path += '/'
+
+    if (args.log_key and not args.log_path) or (args.log_path and not args.log_key):
+        parser.error("You must specify both the path to the log files and the key to parse them (--log_key, --log_path).")
+
+    if args.classad:
+        file_per_job = get_input_file_from_classad(condor_jobs, args.classad)
+    elif args.log_path:
+        file_per_job = get_input_file(args.log_path, condor_jobs, args.log_key)
+    else:
+        parser.error("You must select a method to obtain the input file information (--classad and/or --log_path/--log_key).")
+    
+    file_and_site_per_file = find_site(file_per_job, args.prefer_us_sites)
+
+    return file_and_site_per_file
+
+if __name__ == "__main__":
+    find_input_file_site_per_job()

--- a/python/file_finder.py
+++ b/python/file_finder.py
@@ -21,19 +21,19 @@ def find_nth(haystack, needle, n):
 def find_site(file_per_job, preferred_sites = None, prefer_us_sites = False, verbose = False):
     file_and_site_per_job = {}
     if verbose:
-        fprint("Finding the sites for each file ...", False)
+        fprint("Finding the sites for each file ...", True)
     for i, (job, file) in enumerate(file_per_job.iteritems()):
         if file is None:
             file_and_site_per_job[job] = (file,None,[None])
         else:
             cmd = "dasgoclient -query=\"site file=" + file + "\""
+            if verbose:
+                fprint("\t" + cmd, True)
             p = subprocess.Popen(cmd, shell = True, stdout=subprocess.PIPE)
             out, err = p.communicate()
             sites = [None] if "WARNING:" in out else out.split()
             site = select_site(sites, preferred_sites, prefer_us_sites)
             file_and_site_per_job[job] = (file,site,sites)
-    if verbose:
-        fprint("DONE")
     return file_and_site_per_job
 
 def get_input_file(basepath, jobs, key, verbose = False):

--- a/python/manageJobs.py
+++ b/python/manageJobs.py
@@ -217,7 +217,7 @@ def manageJobs(argv=None):
     group.add_option("-K", "--log_key", dest="logKey", default = "", type="string", help="key to use to find the correct line(s) in the log file (default = %default)")
     group.add_option("-L", "--log_path", dest="logPath", default = os.environ["PWD"], type="string", help = "path to the job logs (default = %default)")
     group.add_option("-O", "--xrootd-resubmit-options-other", dest="xrootdResubmitOptionsOther", default="", type="string", help = "other options to supply to file_finder_resubmitter.py (default = %default)")
-    group.add_option("-U", "--prefer-us-sites", dest="preferUSSites", action = "store_true", default = False, help = "preferentially select US sites over others (default = %default)")
+    group.add_option("-U", "--prefer-us-sites", dest="preferUSSites", action = "store_true", default = False, help = "prefer reading inputs from US sites over others (default = %default)")
     group.add_option("-V", "--verbose", dest="verbose", action = "store_true", default = False, help = "be more verbose when printing out the resubmission information for each job (default = %default)")
     parser.add_option_group(group)
     parser.add_option("--add-sites", dest="addsites", default=[], type="string", action="callback", callback=list_callback, help='comma-separated list of global pool sites to add (default = %default)')

--- a/python/manageJobs.py
+++ b/python/manageJobs.py
@@ -1,5 +1,6 @@
 import sys,os,subprocess,glob,shutil,json
-from optparse import OptionParser
+from optparse import OptionParser, OptionGroup
+from file_finder import find_input_file_site_per_job
 
 # try to find condor bindings
 for condorPath in ["/usr/lib64/python2.6/site-packages", "/usr/lib64/python2.7/site-packages"]:
@@ -10,7 +11,7 @@ import htcondor,classad
 from parseConfig import list_callback, parser_dict
 
 class CondorJob(object):
-    def __init__(self, result, schedd):
+    def __init__(self, options, result, schedd):
         self.stdout = result["Out"].replace(".stdout","")
         self.name = "_".join(self.stdout.split('_')[:-1])
         self.num = str(result["ClusterId"])+"."+str(result["ProcId"])
@@ -34,6 +35,8 @@ class CondorJob(object):
         self.time = (float(result["ChirpCMSSWElapsed"]) if "ChirpCMSSWElapsed" in result.keys() else 0.0)/float(3600)
         self.events = int(result["ChirpCMSSWEvents"]) if "ChirpCMSSWEvents" in result.keys() else 0
         self.rate = float(self.events)/(self.time*3600) if self.time>0 else 0
+        if options.inputFileClassAd in result.keys():
+            self.inputFiles = result[options.inputFileClassAd]
 
 def getJob(options,result,jobs,scheddurl=""):
     # check greps
@@ -58,7 +61,7 @@ def getJob(options,result,jobs,scheddurl=""):
         tdiff = time - update
         if time>0 and update>0 and tdiff>(options.stuckThreshold*3600): result["HoldReason"] = "Job stuck for "+str(tdiff/3600)+" hours"
         else: return
-    jobs.append(CondorJob(result,scheddurl))
+    jobs.append(CondorJob(options,result,scheddurl))
 
 def getSchedd(scheddurl,coll=""):
     if len(scheddurl)>0:
@@ -85,6 +88,8 @@ def getJobs(options, scheddurl=""):
     # get info for selected jobs
     jobs = []
     props = ["ClusterId","ProcId","HoldReason","Out","Args","Arguments","JobStatus","ServerTime","ChirpCMSSWLastUpdate","ChirpCMSSWElapsed","ChirpCMSSWEvents","DESIRED_Sites","MATCH_EXP_JOB_GLIDEIN_CMSSite","RemoteHost","LastRemoteHost"]
+    if options.inputFileClassAd:
+        props.append(options.inputFileClassAd)
     if options.finished>0:
         for result in schedd.history(constraint,props,options.finished):
             getJob(options,result,jobs,scheddurl)
@@ -204,10 +209,22 @@ def manageJobs(argv=None):
     parser.add_option("-w", "--why", dest="why", default=False, action="store_true", help="show why a job was held (default = %default)")
     parser.add_option("-m", "--matched", dest="matched", default=False, action="store_true", help="show site and machine to which the job matched (default = %default)")
     parser.add_option("-p", "--progress", dest="progress", default=False, action="store_true", help="show job progress (time and nevents) (default = %default)")
+    parser.add_option("-X", "--xrootd-resubmit", dest="xrootdResubmit", default=False, action="store_true", help="resubmit the jobs based on where the input files are located (default = %default)")
+    group = OptionGroup(parser, "Site Specific Resubmit Options",
+                        "The options for resubmitting jobs based on where there input files are stored (-X, --xrootd-resubmit).")
+    group.add_option("-C", "--input-file-classad", dest="inputFileClassAd", default = "", type="string", help = "HTCondor ClassAd which contains the input file(s) being used within the job (default = %default)")
+    group.add_option("-D", "--dry-run", dest="dryRun", default=False, action="store_true", help="don't actually resubmit any jobs (default = %default)")
+    group.add_option("-K", "--log_key", dest="logKey", default = "", type="string", help="key to use to find the correct line(s) in the log file (default = %default)")
+    group.add_option("-L", "--log_path", dest="logPath", default = os.environ["PWD"], type="string", help = "path of the job logs (default: %default)")
+    group.add_option("-O", "--xrootd-resubmit-options-other", dest="xrootdResubmitOptionsOther", default="", type="string", help = "other options to supply to file_finder_resubmitter.py (default = %default)")
+    group.add_option("-U", "--prefer-us-sites", dest="preferUSSites", action = "store_true", default = False, help = "preferentially select US sites over others (default: %default)")
+    parser.add_option_group(group)
     parser.add_option("--add-sites", dest="addsites", default=[], type="string", action="callback", callback=list_callback, help='comma-separated list of global pool sites to add (default = %default)')
+    parser.add_option("--quiet", dest="quiet", default=False, action="store_true", help="silence the default print statements (default = %default)")
     parser.add_option("--rm-sites", dest="rmsites", default=[], type="string", action="callback", callback=list_callback, help='comma-separated list of global pool sites to remove (default = %default)')
     parser.add_option("--stuck-threshold", dest="stuckThreshold", default=12, help="threshold in hours to define stuck jobs (default = %default)")
     parser.add_option("--ssh", dest="ssh", action="store_true", default=False, help='internal option if script is run recursively over ssh')
+    parser.add_option("--verbose", dest="verbose", action="store_true", default=False, help="print additional information to the screen (default = %default)")
     parser.add_option("--help", dest="help", action="store_true", default=False, help='show this help message')
     (options, args) = parser.parse_args(args=argv)
 
@@ -224,6 +241,8 @@ def manageJobs(argv=None):
         parser.error("Options -h, -r, -i, -f are exclusive, pick one!")
     if options.resubmit and options.kill:
         parser.error("Can't use -s and -k together, pick one!")
+    if options.xrootdResubmit and options.kill:
+        parser.error("Can't use -X and -k together, pick one!")
     if len(options.xrootd)>0 and options.xrootd[0:7] != "root://" and options.xrootd[0] != "T":
         parser.error("Improper xrootd address: "+options.xrootd)
     if len(options.user)==0:
@@ -242,6 +261,7 @@ def manageJobs(argv=None):
     if options.finished>0:
         options.resubmit = False
         options.kill = False
+        options.xrootdResubmit = False
         
     if options.all: all_nodes = parser_dict["schedds"]["fnal"].split(',')
     else: all_nodes = [""]
@@ -249,7 +269,7 @@ def manageJobs(argv=None):
         jobs = getJobs(options,sch)
         if len(jobs)>0:
             if len(sch)>0: print sch
-            printJobs(jobs,options.num,options.progress,options.stdout,options.why,options.matched)
+            if not options.quiet: printJobs(jobs,options.num,options.progress,options.stdout,options.why,options.matched)
 
             # resubmit or remove jobs
             if options.resubmit:
@@ -260,7 +280,39 @@ def manageJobs(argv=None):
                 # actions that can be applied to all jobs
                 jobnums = [j.num for j in jobs]
                 schedd.act(htcondor.JobAction.Remove,jobnums)
+            elif options.xrootdResubmit:
+                print ""
+                file_and_site_per_file = find_input_file_site_per_job(argv = (["-c", options.inputFileClassAd] if options.inputFileClassAd else []) +
+                                                                             (["-k", options.logKey] if options.logKey and options.logPath else []) +
+                                                                             (["-l", options.logPath] if options.logKey and options.logPath else []) +
+                                                                             (["-u"] if options.preferUSSites else []) +
+                                                                             options.xrootdResubmitOptionsOther.split(), condor_jobs = jobs);
 
+                jobs_resubmitted = {}
+                jobs_not_resubmitted = {}
+                print "Resubmitting jobs (dryRun = " + str(options.dryRun) + ") ...",
+                sys.stdout.flush()
+                original_xrootd_option = options.xrootd
+                for job, (file, site, sites) in file_and_site_per_file.iteritems():
+                    if site is None and not options.xrootd:
+                        jobs_not_resubmitted[job.stdout] = (file, site, sites)
+                    else:
+                        jobs_resubmitted[job.stdout] = (file, site, sites)
+                        if not options.dryRun:
+                            options.xrootd = site if site is not None else original_xrootd_option
+                            resubmitJobs([job],options,sch)
+                print "DONE"
+
+                if options.verbose:
+                    print "\nJobs resubmitted:"
+                    fmt = "\t{0:>80s}: file={1:<100s} site={2:<20s}"
+                    for job, (file, site, sites) in jobs_resubmitted.iteritems():
+                        print fmt.format(job,file,site)
+
+                    print "\nJobs not resubmitted due to lack of an acceptable site:"
+                    fmt = "\t{0:>80s}: file={1:<100s} sites={2:<30s}"
+                    for job, (file, site, sites) in jobs_not_resubmitted.iteritems():
+                        print fmt.format(job,file,str(sites))
 
 if __name__=="__main__":
     manageJobs()

--- a/python/manageJobs.py
+++ b/python/manageJobs.py
@@ -248,6 +248,8 @@ def manageJobs(argv=None):
         parser.error("To gather the input file names, you must specify either a classad (-C) or the path (-L) to some logs and the key to parse them (-K), choose your method!")
     if options.xrootdResubmit and options.logKey and not options.logPath:
         parser.error("When specifying a key for log parsing you must also specify the path to the logs (-L)")
+    if options.xrootdResubmit and not options.inputFileClassAd and options.logPath and not options.logKey:
+        parser.error("When specifying a path for log parsing you must also specify the key with which to parse the logs (-K)")
     if len(options.xrootd)>0 and options.xrootd[0:7] != "root://" and options.xrootd[0] != "T":
         parser.error("Improper xrootd address: "+options.xrootd)
     if len(options.user)==0:
@@ -288,18 +290,15 @@ def manageJobs(argv=None):
             elif options.xrootdResubmit:
                 fprint("")
                 file_and_site_per_file = {}
-                try:
-                    file_and_site_per_file = find_input_file_site_per_job(
-                        classad = options.inputFileClassAd,
-                        condor_jobs = jobs,
-                        log_key = options.logKey if options.logKey and options.logPath else "",
-                        log_path = options.logPath if options.logKey and options.logPath else "",
-                        prefer_us_sites = options.preferUSSites,
-                        verbose = options.verbose,
-                    )
-                except Exception as e:
-                    fprint(e)
-                    return
+                file_and_site_per_file = find_input_file_site_per_job(
+                    classad = options.inputFileClassAd,
+                    condor_jobs = jobs,
+                    log_key = options.logKey if options.logKey and options.logPath else "",
+                    log_path = options.logPath if options.logKey and options.logPath else "",
+                    preferred_sites = parser_dict["manage"]["preferredsites"].split(",") if "preferredsites" in parser_dict["manage"].keys() else None,
+                    prefer_us_sites = options.preferUSSites,
+                    verbose = options.verbose,
+                )
 
                 jobs_resubmitted = {}
                 jobs_not_resubmitted = {}


### PR DESCRIPTION
## Overview
Add the ability to resubmit jobs based on the site where the input file(s) are located, as reported by DAS. This functionality relies on a new python module, `file_finder.py`, which does all of the heavy lifting in terms of finding the input file(s) for each job and finding our the site(s) where this file is located.

The goal is to add this functionality while affecting the rest of `manageJobs.py` as little as possible.

## Options

There are two ways in which the input filename can be obtained:
1. The filename(s) can be added to an HTCondor ClassAd as done in https://github.com/TreeMaker/TreeMaker/pull/619 and then the ClassAd name can be specified using the option `-C` or `--input-file-classad`. If there is more than one file, it is assumed that this is a comma separated list of files and only the first one is selected.
2. The filename can be retrieved from a log file. In this case, the user must supply the path to the log files (`-L`, `--log_path`, defaults to the CWD) and a key with which to find the filename (`-K`, `--log_key`). If there is more than one file, it is assumed that this line contains a comma separated list of files and only the first one is selected.

If the options for both methods are specified, the code will prefer to use the ClassAd to obtain the information.

Example commands are:
```bash
manageJobs.py -aX  -C <ClassAd name> --verbose
manageJobs.py -aX -K "<key>" --verbose
```

The `--verbose` option prints out some additional information at the end of resubmitting the jobs. Additionally, there is a `--dry-run` option (also `-D`) in case the user would like to see what the command would do in terms of finding site before resubmitting the jobs. The final option, `--prefer-us-sites` (`-U`), allows the user to select US sites, if available, over other sites.

## Notes and Limitations
- The code currently only looks at the site for the first input file in a list (assumed to be comma separated).
- For obvious reasons if the ClassAd hasn't been set yet or there is no log file to open, then the jobs will not be resubmitted. Using the `--verbose` option will show which jobs weren't resubmitted and why.
- If the option `-x` is used, this new re-submission mechanism will override the user specified site. However, if no site can be found based on this automated mechanism, the it will default to what the user specified in the original command.