### PR TITLE
Blacklist Sites for XRootD Resubmit

### DIFF
--- a/python/file_finder.py
+++ b/python/file_finder.py
@@ -18,7 +18,7 @@ def find_nth(haystack, needle, n):
         n -= 1
     return start
 
-def find_site(file_per_job, preferred_sites = None, prefer_us_sites = False, verbose = False):
+def find_site(file_per_job, preferred_sites = None, prefer_us_sites = False, blacklisted_sites = None, verbose = False):
     file_and_site_per_job = {}
     if verbose:
         fprint("Finding the sites for each file ...", True)
@@ -32,7 +32,7 @@ def find_site(file_per_job, preferred_sites = None, prefer_us_sites = False, ver
             p = subprocess.Popen(cmd, shell = True, stdout=subprocess.PIPE)
             out, err = p.communicate()
             sites = [None] if "WARNING:" in out else out.split()
-            site = select_site(sites, preferred_sites, prefer_us_sites)
+            site = select_site(sites, preferred_sites, prefer_us_sites, blacklisted_sites)
             file_and_site_per_job[job] = (file,site,sites)
     return file_and_site_per_job
 
@@ -76,9 +76,10 @@ def get_input_file_from_classad(jobs, classad, verbose = False):
 def lines_that_contain(string, fp):
     return [line for line in fp if string in line]
 
-def select_site(sites, preferred_sites = None, prefer_us_sites = False):
+def select_site(sites, preferred_sites = None, prefer_us_sites = False, blacklisted_sites = None):
     selected = None
     sites = [s.replace("_Disk","") for s in sites if s is not None and "Tape" not in s]
+    sites = [s for s in sites if s not in blacklisted_sites]
     sites = sorted(sites, key = lambda x: (prefer_us_sites and "US" in x.split('_')[1]), reverse = True)
     if preferred_sites is not None:
         for psite in reversed(preferred_sites):
@@ -88,7 +89,14 @@ def select_site(sites, preferred_sites = None, prefer_us_sites = False):
         selected = sites[0]
     return selected
 
-def find_input_file_site_per_job(classad = "", condor_jobs = None, log_key = "", log_path = "", preferred_sites = None, prefer_us_sites = False, verbose = False):
+def find_input_file_site_per_job(blacklisted_sites = None,
+                                 classad = "",
+                                 condor_jobs = None,
+                                 log_key = "",
+                                 log_path = "",
+                                 preferred_sites = None,
+                                 prefer_us_sites = False,
+                                 verbose = False):
     if condor_jobs is None:
         return
 
@@ -107,7 +115,7 @@ def find_input_file_site_per_job(classad = "", condor_jobs = None, log_key = "",
         fprint("file_finder.py: error: You must select a method to obtain the input file information (--classad and/or --log_path/--log_key).")
         sys.exit(2)
     
-    file_and_site_per_file = find_site(file_per_job, preferred_sites, prefer_us_sites, verbose)
+    file_and_site_per_file = find_site(file_per_job, preferred_sites, prefer_us_sites, blacklisted_sites, verbose)
 
     return file_and_site_per_file
 

--- a/python/manageJobs.py
+++ b/python/manageJobs.py
@@ -212,7 +212,7 @@ def manageJobs(argv=None):
     parser.add_option("-X", "--xrootd-resubmit", dest="xrootdResubmit", default=False, action="store_true", help="resubmit the jobs based on where the input files are located (default = %default)")
     group = OptionGroup(parser, "Site Specific Resubmit Options",
                         "The options for resubmitting jobs based on where their input files are stored (-X, --xrootd-resubmit).")
-    group.add_option("-B", "--blacklist-sites", dest="blacklistedSites", default = [], type = "string", action="callback", callback=list_callback, help = "comma-separated list of global pool sites to reject (default = %default)")
+    group.add_option("-B", "--blacklist-sites", dest="blacklistedSites", default = parser_dict["manage"]["blacklistedsites"], type = "string", action="callback", callback=list_callback, help = "comma-separated list of global pool sites to reject (default = %default)")
     group.add_option("-C", "--input-file-classad", dest="inputFileClassAd", default = "", type="string", help = "HTCondor ClassAd which contains the input file(s) being used within the job (default = %default)")
     group.add_option("-D", "--dry-run", dest="dryRun", default=False, action="store_true", help="don't actually resubmit any jobs (default = %default)")
     group.add_option("-K", "--log_key", dest="logKey", default = "", type="string", help="key to use to find the correct line(s) in the log file (default = %default)")
@@ -292,7 +292,7 @@ def manageJobs(argv=None):
                 fprint("")
                 file_and_site_per_file = {}
                 file_and_site_per_file = find_input_file_site_per_job(
-                    blacklisted_sites = options.blacklistedSites + (parser_dict["manage"]["blacklistedsites"].split(",") if "blacklistedsites" in parser_dict["manage"].keys() else []),
+                    blacklisted_sites = options.blacklistedSites,
                     classad = options.inputFileClassAd,
                     condor_jobs = jobs,
                     log_key = options.logKey if options.logKey and options.logPath else "",

--- a/python/manageJobs.py
+++ b/python/manageJobs.py
@@ -212,6 +212,7 @@ def manageJobs(argv=None):
     parser.add_option("-X", "--xrootd-resubmit", dest="xrootdResubmit", default=False, action="store_true", help="resubmit the jobs based on where the input files are located (default = %default)")
     group = OptionGroup(parser, "Site Specific Resubmit Options",
                         "The options for resubmitting jobs based on where their input files are stored (-X, --xrootd-resubmit).")
+    group.add_option("-B", "--blacklist-sites", dest="blacklistedSites", default = [], type = "string", action="callback", callback=list_callback, help = "comma-separated list of global pool sites to reject (default = %default)")
     group.add_option("-C", "--input-file-classad", dest="inputFileClassAd", default = "", type="string", help = "HTCondor ClassAd which contains the input file(s) being used within the job (default = %default)")
     group.add_option("-D", "--dry-run", dest="dryRun", default=False, action="store_true", help="don't actually resubmit any jobs (default = %default)")
     group.add_option("-K", "--log_key", dest="logKey", default = "", type="string", help="key to use to find the correct line(s) in the log file (default = %default)")
@@ -291,6 +292,7 @@ def manageJobs(argv=None):
                 fprint("")
                 file_and_site_per_file = {}
                 file_and_site_per_file = find_input_file_site_per_job(
+                    blacklisted_sites = options.blacklistedSites + (parser_dict["manage"]["blacklistedsites"].split(",") if "blacklistedsites" in parser_dict["manage"].keys() else []),
                     classad = options.inputFileClassAd,
                     condor_jobs = jobs,
                     log_key = options.logKey if options.logKey and options.logPath else "",


### PR DESCRIPTION
Adds an option to blacklist sites when resubmitting jobs based on the location of the input files. This has been tested and appears to work. The user can specify the blacklist either using the command line options or in one of the `.prodconfig` files.